### PR TITLE
Added damagetype check to healthsystem and created damageableobject

### DIFF
--- a/Assets/Art/Materials/Dev Materials/HealthOrbMat.mat
+++ b/Assets/Art/Materials/Dev Materials/HealthOrbMat.mat
@@ -1,0 +1,84 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: HealthOrbMat
+  m_Shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords:
+  - _EMISSION
+  m_InvalidKeywords: []
+  m_LightmapFlags: 1
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _BumpScale: 1
+    - _Cutoff: 0.5
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _GlossMapScale: 1
+    - _Glossiness: 0.5
+    - _GlossyReflections: 1
+    - _Metallic: 0
+    - _Mode: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.02
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _UVSec: 0
+    - _ZWrite: 1
+    m_Colors:
+    - _Color: {r: 0, g: 1, b: 0.052369833, a: 1}
+    - _EmissionColor: {r: 0.028004408, g: 1, b: 0, a: 1}
+  m_BuildTextureStacks: []

--- a/Assets/Art/Materials/Dev Materials/HealthOrbMat.mat.meta
+++ b/Assets/Art/Materials/Dev Materials/HealthOrbMat.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 36af81bb8d383124197a7b90491ef980
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Droppable Items/HealthOrb.prefab
+++ b/Assets/Prefabs/Droppable Items/HealthOrb.prefab
@@ -62,7 +62,7 @@ MeshRenderer:
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 2100000, guid: 31321ba15b8f8eb4c954353edc038b1d, type: 2}
+  - {fileID: 2100000, guid: 36af81bb8d383124197a7b90491ef980, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0

--- a/Assets/Scenes/Huss Dev Scene.unity
+++ b/Assets/Scenes/Huss Dev Scene.unity
@@ -152,8 +152,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6cffeab62177660478cc7c6b133ce294, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  healthSystem: {fileID: 1365145082}
-  damageTypeSO: {fileID: 11400000, guid: a39d8008fcb92614181af06b2a61240b, type: 2}
+  healthSystem: {fileID: 1114300775}
+  damageTypeSO: {fileID: 11400000, guid: 494a1e5db449980439d7584e253947ed, type: 2}
 --- !u!4 &168931821
 Transform:
   m_ObjectHideFlags: 0
@@ -261,6 +261,156 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1114300769
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1114300773}
+  - component: {fileID: 1114300772}
+  - component: {fileID: 1114300771}
+  - component: {fileID: 1114300770}
+  - component: {fileID: 1114300775}
+  - component: {fileID: 1114300774}
+  - component: {fileID: 1114300776}
+  m_Layer: 0
+  m_Name: BurnableObject Test
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!65 &1114300770
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1114300769}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!23 &1114300771
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1114300769}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &1114300772
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1114300769}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &1114300773
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1114300769}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0.75, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1114300774
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1114300769}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d69b238faaa7d884384a171a87b558f5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &1114300775
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1114300769}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 217dd0aa7852d8441933a7bd60588e8a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  maxHealth: 100
+  currentHealth: 0
+  requiredDamageType: {fileID: 11400000, guid: 2ac3428a4ad1e7643a6fac7b152b86e6, type: 2}
+  isAlive: 0
+--- !u!114 &1114300776
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1114300769}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 311d8edd6b63de843802da78041d7592, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  droppableItems:
+  - {fileID: 11400000, guid: bb29f0d94dfefae4dbcec8b60a1d3822, type: 2}
 --- !u!1 &1353628235
 GameObject:
   m_ObjectHideFlags: 0
@@ -399,6 +549,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   maxHealth: 1000
   currentHealth: 0
+  requiredDamageType: {fileID: 0}
   isAlive: 0
 --- !u!4 &1365145083
 Transform:
@@ -532,3 +683,4 @@ SceneRoots:
   - {fileID: 1353628239}
   - {fileID: 168931821}
   - {fileID: 1365145083}
+  - {fileID: 1114300773}

--- a/Assets/Scripts/Level Mechanics.meta
+++ b/Assets/Scripts/Level Mechanics.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ecc07c0ae968cc944aef9005a29c9010
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Level Mechanics/ActivatableTorch.cs
+++ b/Assets/Scripts/Level Mechanics/ActivatableTorch.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class ActivatableTorch : DamagableObject
+{
+    public override void OnObjectDamaged(object sender, HealthSystem.DamagedEventArgs e) {
+        
+    }
+
+    public override void OnObjectDestroyed(object sender, EventArgs e) {
+
+    }
+}

--- a/Assets/Scripts/Level Mechanics/ActivatableTorch.cs.meta
+++ b/Assets/Scripts/Level Mechanics/ActivatableTorch.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b2e91465e75a68e4c949cdb0c44767ef
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Level Mechanics/BurnableGate.cs
+++ b/Assets/Scripts/Level Mechanics/BurnableGate.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.EventSystems;
+
+public class BurnableGate : DamagableObject
+{
+    public override void OnObjectDamaged(object sender, HealthSystem.DamagedEventArgs e) {
+        Debug.Log("Burnable Gate got burned for " + e.damageAmount);
+    }
+
+    public override void OnObjectDestroyed(object sender, EventArgs e) {
+        Debug.Log("Burnable Gate burned to death");
+        Destroy(this.gameObject);
+    }
+}

--- a/Assets/Scripts/Level Mechanics/BurnableGate.cs.meta
+++ b/Assets/Scripts/Level Mechanics/BurnableGate.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d69b238faaa7d884384a171a87b558f5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Level Mechanics/DamagableObject.cs
+++ b/Assets/Scripts/Level Mechanics/DamagableObject.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+[RequireComponent(typeof(HealthSystem))]
+public abstract class DamagableObject : MonoBehaviour {
+    private HealthSystem healthSystem => GetComponent<HealthSystem>();
+
+    private void OnEnable() {
+        healthSystem.OnDamaged += OnObjectDamaged;
+        healthSystem.OnDie += OnObjectDestroyed;
+    }
+
+    private void OnDisable() {
+        healthSystem.OnDamaged -= OnObjectDamaged;
+        healthSystem.OnDie -= OnObjectDestroyed;
+    }
+    
+    public abstract void OnObjectDamaged(object sender, HealthSystem.DamagedEventArgs e);
+
+    public abstract void OnObjectDestroyed(object sender, EventArgs e);
+}

--- a/Assets/Scripts/Level Mechanics/DamagableObject.cs.meta
+++ b/Assets/Scripts/Level Mechanics/DamagableObject.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 75ed5dff20e7a0c4588846d7c3ceb5b9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/ScriptableObjects/DamageTypes/ChargeDamageSO.cs
+++ b/Assets/Scripts/ScriptableObjects/DamageTypes/ChargeDamageSO.cs
@@ -6,6 +6,6 @@ using UnityEngine;
 public class ChargeDamageSO : DamageTypeSO
 {
     public override void DealDamage(HealthSystem healthSystem, float damageAmount) {
-        healthSystem.TakeDamage(damageAmount);
+        healthSystem.TakeDamage(this, damageAmount);
     }
 }

--- a/Assets/Scripts/ScriptableObjects/DamageTypes/FireDamageSO.cs
+++ b/Assets/Scripts/ScriptableObjects/DamageTypes/FireDamageSO.cs
@@ -27,7 +27,7 @@ public class FireDamageSO : DamageTypeSO
 
         while (isInFlames) {
             // Apply damage each tick
-            healthSystem.TakeDamage(damageAmount);
+            healthSystem.TakeDamage(this, damageAmount);
             Debug.Log($"Damage tick");
 
             // Delay for the specified time between ticks
@@ -38,7 +38,7 @@ public class FireDamageSO : DamageTypeSO
             for (int i = 0; i < TicksPerSecond * EffectDuration; i++) {
                 // Apply damage each tick
                 // Note: You may want to add a check here if isInFlames becomes true again during the continuation.
-                healthSystem.TakeDamage(damageAmount);
+                healthSystem.TakeDamage(this, damageAmount);
                 Debug.Log($"Damage tick {i + 1}");
 
                 // Delay for the specified time between ticks

--- a/Assets/Scripts/ScriptableObjects/DamageTypes/IceDamageSO.cs
+++ b/Assets/Scripts/ScriptableObjects/DamageTypes/IceDamageSO.cs
@@ -7,6 +7,6 @@ public class IceDamageSO : DamageTypeSO
 {
     // Instant Damage.
     public override void DealDamage(HealthSystem healthSystem, float damageAmount) {
-        healthSystem.TakeDamage(damageAmount);
+        healthSystem.TakeDamage(this, damageAmount);
     }
 }

--- a/Assets/Scripts/ScriptableObjects/DamageTypes/PhysicalDamageSO.cs
+++ b/Assets/Scripts/ScriptableObjects/DamageTypes/PhysicalDamageSO.cs
@@ -7,6 +7,6 @@ public class PhysicalDamageSO : DamageTypeSO
 {
     // Instant Damage
     public override void DealDamage(HealthSystem healthSystem, float damageAmount) {
-        healthSystem.TakeDamage(damageAmount);
+        healthSystem.TakeDamage(this, damageAmount);
     }
 }

--- a/Assets/Scripts/ScriptableObjects/DamageTypes/StunDamageSO.cs
+++ b/Assets/Scripts/ScriptableObjects/DamageTypes/StunDamageSO.cs
@@ -6,10 +6,10 @@ using UnityEngine;
 public class StunDamageSO : DamageTypeSO
 {
     public override void DealDamage(HealthSystem healthSystem, float damageAmount) {
-        // if(TryGetGetComponent<???>(out ??? nameHere)) {
-        //     //Call the StunFunction from the component
+        // if(healthSystem.TryGetComponent(out Character character)){
+        //     character.ApplyStatusEffectToCharacter(StatusEffect.Stun);
         // }
 
-        healthSystem.TakeDamage(damageAmount);
+        healthSystem.TakeDamage(this, damageAmount);
     }
 }

--- a/Assets/Scripts/Systems/HealthSystem.cs
+++ b/Assets/Scripts/Systems/HealthSystem.cs
@@ -9,12 +9,22 @@ public class HealthSystem : MonoBehaviour {
     [Header("Editable Variables")]
     [SerializeField] private float maxHealth;
     [SerializeField] private float currentHealth;
+    [SerializeField] private DamageTypeSO requiredDamageType;
 #endregion
 
 #region Events
     public event EventHandler OnDie; //Used for whenever a player is killed.
-    public event EventHandler OnDamaged; //Used for any events that happen when player is damaged.
+    public event EventHandler<DamagedEventArgs> OnDamaged; //Used for any events that happen when player is damaged.
     public event EventHandler OnHealed; //Used for anything that happens when a player gets healed
+
+    public class DamagedEventArgs : EventArgs {
+        public DamageTypeSO damageTypeSO;
+        public float damageAmount;
+        public DamagedEventArgs(DamageTypeSO _damageTypeSO, float _damageAmount) {
+            damageTypeSO = _damageTypeSO;
+            damageAmount = _damageAmount;
+        }
+    }
 #endregion
 
     [SerializeField] private bool isAlive;
@@ -25,10 +35,13 @@ public class HealthSystem : MonoBehaviour {
     }
 
     //Need way to modify current health
-    public void TakeDamage(float damageAmount) {
-        if(!isAlive) {
+    public void TakeDamage(DamageTypeSO damageType, float damageAmount) {
+        if(requiredDamageType != null && damageType != requiredDamageType) {
+            return;
+        } if(!isAlive) {
             return;
         }
+
         currentHealth -= damageAmount;
 
         if(currentHealth < 0) {
@@ -36,7 +49,7 @@ public class HealthSystem : MonoBehaviour {
         }
 
         //Need to update Player UI when damage taken/healed
-        OnDamaged?.Invoke(this, EventArgs.Empty); //cause any event subscribed to activate when hit.
+        OnDamaged?.Invoke(this, new DamagedEventArgs(damageType, damageAmount)); //cause any event subscribed to activate when hit.
 
         if(currentHealth == 0) {
             Die();
@@ -59,4 +72,4 @@ public class HealthSystem : MonoBehaviour {
         isAlive = false;
         OnDie?.Invoke(this, EventArgs.Empty);
     }
-}
+ }


### PR DESCRIPTION
The DamageableObject is used for objects like burnable doors, crates, and stuff that can be destroyed by the players.

DamageableObject class gets inherited by anything needing it.